### PR TITLE
__setitem__ should fail loudly

### DIFF
--- a/ojota/base.py
+++ b/ojota/base.py
@@ -177,7 +177,7 @@ class OjotaSet(MutableSequence):
         del self._list[ii]
 
     def __setitem__(self, ii, val):
-        return self._list[ii]
+        raise NotImplementedError
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
since it isn't implemented "pythonically"
